### PR TITLE
Add integration tests for IssueRepository with in-memory DB

### DIFF
--- a/API.Tests/API.Tests.csproj
+++ b/API.Tests/API.Tests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/API.Tests/RepoTests/IssueRepositoryTests.cs
+++ b/API.Tests/RepoTests/IssueRepositoryTests.cs
@@ -1,0 +1,86 @@
+using API.Data;
+using API.Helpers;
+using API.Models;
+using API.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace API.API.Tests.RepoTests;
+
+public class IssueRepositoryTests
+{
+ 
+
+  [Fact]
+  public async Task AddAsync_ShouldAddIssue()
+  {
+    
+    var context = TestDbContextFactory.Create();
+    var repo = new IssueRepository(context);
+    var issue = new Issue
+    {
+      Description = "Test Issue",
+      StatusId = 1,
+      IssueTypeId = 1,
+      CreatedAt = DateTime.UtcNow,
+      DateUpdated = null
+    };
+
+    await repo.AddAsync(issue);
+    var issues = await context.Issues.ToListAsync();
+
+    Assert.Single(issues);
+    Assert.Equal("Test Issue", issues[0].Description);
+  }
+  [Fact]
+  public async Task GetAllAsync_ShouldReturnIssuesWithIncludes()
+  {
+    
+    var context = TestDbContextFactory.Create();
+    var repo = new IssueRepository(context);
+
+    context.Issues.Add(new Issue
+    {
+      Description = "Sample",
+      StatusId = 1,
+      IssueTypeId = 1,
+      CreatedAt = DateTime.UtcNow
+    });
+    await context.SaveChangesAsync();
+
+    
+    var issues = await repo.GetAllAsync();
+
+    
+    Assert.Single(issues);
+    Assert.NotNull(issues[0].Status);
+    Assert.NotNull(issues[0].IssueType);
+  }
+
+  [Fact]
+  public async Task GetByIdAsync_ShouldReturnCorrectIssue()
+  {
+
+    var context = TestDbContextFactory.Create();
+    var repo = new IssueRepository(context);
+
+    context.Issues.Add(new Issue
+    {
+      Id = 99,
+      Description = "Specific",
+      StatusId = 1,
+      IssueTypeId = 1,
+      CreatedAt = DateTime.UtcNow
+    });
+    await context.SaveChangesAsync();
+
+    
+    var issue = await repo.GetByIdAsync(99);
+
+    
+    Assert.NotNull(issue);
+    Assert.Equal("Specific", issue.Description);
+    Assert.NotNull(issue.Status);
+    Assert.NotNull(issue.IssueType);
+  }
+}

--- a/API.csproj
+++ b/API.csproj
@@ -9,12 +9,19 @@
   <ItemGroup>
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/API.sln
+++ b/API.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.13.35931.197 d17.13
+VisualStudioVersion = 17.13.35931.197
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "API", "API.csproj", "{C11D9C18-893D-419B-BB3E-FF049C9786E1}"
 EndProject

--- a/Helpers/TestDbContextFactory.cs
+++ b/Helpers/TestDbContextFactory.cs
@@ -1,0 +1,25 @@
+using API.Data;
+using API.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Helpers
+{
+  public static class TestDbContextFactory
+  {
+    public static AppDbContext Create()
+    {
+      var options = new DbContextOptionsBuilder<AppDbContext>()
+          .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+          .Options;
+
+      var context = new AppDbContext(options);
+
+      
+      context.Statuses.Add(new Status { Id = 1, Name = "Open" });
+      context.IssueTypes.Add(new IssueType { Id = 1, Name = "Bug" });
+      context.SaveChanges();
+
+      return context;
+    }
+  }
+}


### PR DESCRIPTION
- Implemented integration tests for IssueRepository: • AddAsync_ShouldAddIssue • GetAllAsync_ShouldReturnAllIssues • GetByIdAsync_ShouldReturnCorrectIssue

- Created TestDbContextFactory helper for reusable in-memory AppDbContext setup
- Installed xUnit, xUnit runner, and EF Core InMemory packages for test support