### PR TITLE
Add unit test for IssueService.CreateIssueAsync

### DIFF
--- a/API.Tests/RepoTests/IssueServiceTests.cs
+++ b/API.Tests/RepoTests/IssueServiceTests.cs
@@ -1,0 +1,36 @@
+using API.Dtos;
+using API.Repositories;
+using API.Services;
+using Xunit;
+using Moq;
+using API.Models;
+
+namespace API.API.Tests.RepoTests
+{
+  public class IssueServiceTests
+  {
+    private readonly Mock<IIssueRepository> _mockRepo;
+    private readonly IssueService _service;
+
+    public IssueServiceTests()
+    {
+      _mockRepo = new Mock<IIssueRepository>();
+      _service = new IssueService(_mockRepo.Object);
+    }
+
+    [Fact]
+    public async Task CreateIssueAsync_ShouldCallAddAsync_WithMappedIssue()
+    {
+      var request = new IssueRequestDto
+      {
+        Description = "Test issue",
+        IssueTypeId = 1
+      };
+      await _service.CreateIssueAsync(request);
+
+      _mockRepo.Verify(repo => repo.AddAsync(It.Is<Issue>(
+          issue => issue.Description == "Test issue" && issue.IssueTypeId == 1 && issue.StatusId == 1
+      )), Times.Once);
+    }
+  }
+}

--- a/API.csproj
+++ b/API.csproj
@@ -16,6 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">


### PR DESCRIPTION
- Verified repository AddAsync is called with correctly mapped Issue entity
- Used Moq to mock IIssueRepository
- Ensured service logic runs in isolation from data layer