### PR TITLE
Add global exception handling middleware

### DIFF
--- a/API.Tests/ServiceTests/IssueServiceTests.cs
+++ b/API.Tests/ServiceTests/IssueServiceTests.cs
@@ -32,5 +32,50 @@ namespace API.API.Tests.ServiceTests
           issue => issue.Description == "Test issue" && issue.IssueTypeId == 1 && issue.StatusId == 1
       )), Times.Once);
     }
+    [Fact]
+    public async Task GetAllIssueAsync_ShouldReturnMappedResponse()
+    {
+      var issues = new List<Issue>
+        {
+            new Issue
+            {
+                Id = 1,
+                Description = "Issue 1",
+                Status = new Status { Id = 1, Name = "Open" },
+                StatusId = 1,
+                IssueType = new IssueType { Id = 1, Name = "Bug" },
+                IssueTypeId = 1
+            }
+        };
+
+      _mockRepo.Setup(r => r.GetAllAsync()).ReturnsAsync(issues);
+      var result = await _service.GetAllIssueAsync();
+
+      Assert.Single(result);
+      Assert.Equal("Issue 1", result[0].Description);
+      Assert.Equal("Open", result[0].Status.Name);
+      Assert.Equal("Bug", result[0].IssueType.Name);
+    }
+
+    [Fact]
+    public async Task GetIssueByIdAsync_ShouldReturnCorrectIssue()
+    {
+      var issue = new Issue
+      {
+        Id = 1,
+        Description = "Issue 1",
+        Status = new Status { Id = 1, Name = "Open" },
+        StatusId = 1,
+        IssueType = new IssueType { Id = 1, Name = "Bug" },
+        IssueTypeId = 1
+      };
+
+      _mockRepo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(issue);
+      var result = await _service.GetIssueByIdAsync(1);
+
+      Assert.NotNull(result);
+      Assert.Equal("Issue 1", result.Description);
+      Assert.Equal("Open", result.Status.Name);
+    }
   }
 }

--- a/Middleware/ExceptionHandlingMiddleware.cs
+++ b/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace API.Middleware
+{
+  public class ExceptionHandlingMiddleware
+  {
+    private readonly RequestDelegate _next;
+    private readonly ILogger<ExceptionHandlingMiddleware> _logger;
+    private readonly IWebHostEnvironment _env;
+
+    public ExceptionHandlingMiddleware(RequestDelegate next, ILogger<ExceptionHandlingMiddleware> logger, IWebHostEnvironment env)
+    {
+      _next = next;
+      _logger = logger;
+      _env = env;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+      try
+      {
+        await _next(context);
+      }
+      catch (Exception ex)
+      {
+        _logger.LogError(ex, "Unhandled exception occurred while processing request");
+
+        var problem = new ProblemDetails
+        {
+          Status = StatusCodes.Status500InternalServerError,
+          Title = "An unexpected error occurred",
+          Detail = _env.IsDevelopment() ? ex.ToString() : null,
+          Instance = context.Request.Path
+        };
+
+        context.Response.StatusCode = problem.Status.Value;
+        context.Response.ContentType = "application/problem+json";
+
+        await context.Response.WriteAsJsonAsync(problem);
+      }
+    }
+  }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,6 @@
 
 using API.Data;
+using API.Middleware;
 using API.Repositories;
 using API.Services;
 using DotNetEnv;
@@ -30,6 +31,7 @@ if (app.Environment.IsDevelopment())
   app.UseSwaggerUI();
 }
 
+app.UseMiddleware<ExceptionHandlingMiddleware>();
 app.UseHttpsRedirection();
 
 app.UseAuthorization();


### PR DESCRIPTION
Introduce custom `ExceptionHandlingMiddleware` This centralizes error handling, ensures consistent formatting, hides stack traces in production, and improves logging.

- Adds middleware class with try-catch around request pipeline
- Integrates ProblemDetails responses with HTTP 500 by default
- Configures middleware early in `Program.cs` before routing and endpoints